### PR TITLE
Update `differential-shellcheck` to `v4`

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -24,6 +24,6 @@ jobs:
           fetch-depth: 0
 
       - name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@latest
+        uses: redhat-plumbers-in-action/differential-shellcheck@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`differential-shellcheck@v4` added support for `on: push` triggers.

Related to:
- https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/215

Also, the `latest` tag is no longer updated:
- https://github.com/redhat-plumbers-in-action/differential-shellcheck/pull/156