### PR TITLE
include microcode by default

### DIFF
--- a/sbupdate.conf
+++ b/sbupdate.conf
@@ -37,7 +37,7 @@ BACKUP=1
 #CMDLINE_DEFAULT="quiet"
 #CMDLINE_ALWAYS="rw root= rootflags="
 #UKI_SUFFIX="-signed.efi"
-#MICROCODES=(/boot/*-ucode.img)
+MICROCODES=(/boot/*-ucode.img)
 #
 #linux_pf=([cmdline]="quiet loglevel=3"
 #          [uki]="linux-pf-test.efi")


### PR DESCRIPTION
I ran into an issue today; I replaced the old sbupdate with this tool, and then started getting "Illegal hardware instruction" crashes from random tools like `node` or even `wc`. Eventually I discovered that my efi image did not contain the microcode package. Applying this patch includes the microcode.

Since the old sbupdate included microcode by default, as far as I'm aware, and *not* having microcode is a bad idea, I propose that this gets included by default.